### PR TITLE
Run scripts in pipeline, add artifacts to `calkit.yaml`, and add repro instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # unh-mhkf1
 
-
 Process raw data and create plots from baseline towing tank experiments at UNH using 1-meter MHKF1 rotor.
+
+To reproduce the results, execute:
+
+```sh
+calkit run
+```

--- a/calkit.yaml
+++ b/calkit.yaml
@@ -4,15 +4,21 @@ description: >-
   at UNH using 1-meter MHKF1 rotor.
 dependencies:
   - git
+  - matlab
 datasets:
-  - path: data/raw/data.parquet
+  - path: data/raw
     title: Raw data
-    description: The raw data from the experiment.
-    stage: collect-data
+    description: >
+      The raw data from the experiment. This includes high frequency time
+      series from all of the sensors and motion control system.
+  - path: data/processed
+    title: Processed data
+    description: Statistical data from the experiment.
+    stage: process-data
 figures:
-  - path: figures/plot.png
-    title: The plot
-    description: The plot.
+  - path: figures/steady-region.png
+    title: Steady region
+    description: An example steady period from a tow tank run.
     stage: plot-data
 owner: meganandd
 name: unh-mhkf1

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -2,16 +2,26 @@ stages:
   process-data:
     cmd: matlab -noFigureWindows -batch "run('scripts/process_data.m');"
     deps:
-      - scripts/process_data.m
       - data/raw
+      - scripts/process_data.m
+      - scripts/functions/get_steady_times.m
+      - scripts/functions/calc_exp_unc.m
+      - scripts/functions/get_rev_mean.m
+      - scripts/functions/crosstalk_correction.m
+      - scripts/functions/read_h5.m
     outs:
       - data/processed:
           cache: false # Keep in Git since they will be small CSVs
   plot-data:
     cmd: matlab -noFigureWindows -batch "run('scripts/plot_figures.m');"
     deps:
-      - scripts/plot_figures.m
       - data/raw
       - data/processed
+      - scripts/plot_figures.m
+      - scripts/functions/plot_blockage_curves.m
+      - scripts/functions/plot_multi_perf_curves.m
+      - scripts/functions/plot_multi_re_curves.m
+      - scripts/functions/plot_perf_curves.m
+      - scripts/functions/plot_re_c.m
     outs:
       - figures

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,13 +1,17 @@
 stages:
-  plot-data:
-    cmd: matlab -noFigureWindows -batch "run('scripts/plot_data.m');"
+  process-data:
+    cmd: matlab -noFigureWindows -batch "run('scripts/process_data.m');"
     deps:
-    - scripts/plot_data.m
-    - data/raw/data.parquet
+      - scripts/process_data.m
+      - data/raw
     outs:
-    - figures/plot.png
-    meta:
-      calkit:
-        type: figure
-        title: The plot
-        description: The plot.
+      - data/processed:
+          cache: false # Keep in Git since they will be small CSVs
+  plot-data:
+    cmd: matlab -noFigureWindows -batch "run('scripts/plot_figures.m');"
+    deps:
+      - scripts/plot_figures.m
+      - data/raw
+      - data/processed
+    outs:
+      - figures


### PR DESCRIPTION
This is just a start and probably won't run properly (with `calkit run`). If I'm reading the plotting scripts/functions correctly no figures are actually saved, so those commands will need to be added.